### PR TITLE
2548: Java SDK: Unable to upload images

### DIFF
--- a/Examples/src/com/froala/examples/servlets/UploadImageValidation.java
+++ b/Examples/src/com/froala/examples/servlets/UploadImageValidation.java
@@ -82,10 +82,22 @@ public class UploadImageValidation extends HttpServlet {
 			responseData = new HashMap<Object, Object>();
 			responseData.put("error", e.toString());
 		}
-		String jsonResponseData = new Gson().toJson(responseData);
-		response.setContentType("application/json");
-		response.setCharacterEncoding("UTF-8");
-		response.getWriter().write(jsonResponseData);
+		// Wait for image to upload
+		synchronized (responseData) {
+			try
+			{
+				responseData.wait(10000);
+				String jsonResponseData = new Gson().toJson(responseData);
+				response.setContentType("application/json");
+				response.setCharacterEncoding("UTF-8");
+				response.getWriter().write(jsonResponseData);
+			}
+			catch ( InterruptedException e )
+			{
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
issue: https://github.com/froala-labs/froala-editor-js-2/issues/2548
description : Java SDK: Unable to upload images
fix : fixed the image upload , implemented the same way as it is done for other image uploading(added a wait for image to be uploaded)